### PR TITLE
Support redis options.auth_pass

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "EventEmitter"
   ],
   "dependencies": {
-    "redis": "0.8.4"
+    "redis": "^0.10.1"
   },
   "devDependencies": {
     "mocha": "1.13.0",


### PR DESCRIPTION
This change adds support for using redis password authentication for both the pubsub receiver and sender by bumping the redis client version to a newer one that supports options.auth_pass.
